### PR TITLE
Add Swobu gateway entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Try out open source models instantly.
 - [lepton.ai](https://www.lepton.ai/)
 - modal.com: on demand Serverless container +GPU execution runtime
 - [agent-command-center-sdk](https://github.com/future-agi/agent-command-center-sdk): OpenAI-compatible gateway SDK for routing AI agent requests across providers
+- [Swobu](https://github.com/swobuforge/swobu): self-hosted local AI gateway (single Go binary, open source, AGPL-3.0) that terminates OpenAI/Anthropic Messages/remote-MCP client traffic and routes across providers, regions, accounts, and local models with failover
 - Predibase: LLM fine-tuning and hosting
 - [https://hpc-ai.com/](HPC AI): GPU rental
 - Replicate.com: models-as-a service


### PR DESCRIPTION
Adds **Swobu** to `## LLM Platforms and APIs` → `### LLM APIs and Inference Services`, next to the existing `agent-command-center-sdk` gateway entry (they're both routing/gateway tools, so kept clustered).

**Swobu** — https://github.com/swobuforge/swobu

A self-hosted local AI gateway (single Go binary, open source, AGPL-3.0) that terminates OpenAI, Anthropic Messages, and remote-MCP client traffic and routes across providers, regions, accounts, and local models with failover. Clients point at one workspace endpoint and name a route; bring-your-own-keys (no resold quota). Actively maintained (last push 2026-07-30), release v1.0.0-rc.2.

Note: the entry's description states it is self-hosted/open-source, so the `SaaS` subheader is clearly used loosely here for the API-access layer (the neighbor `agent-command-center-sdk` is an SDK rather than a hosted service too). Happy to move it if you'd prefer a different section.

Disclosure: I maintain Swobu. Single-purpose diff.